### PR TITLE
Hashed and agnostic animations, play once jump animation option

### DIFF
--- a/Assets/PC2D/Scripts/PlatformerAnimation2D.cs
+++ b/Assets/PC2D/Scripts/PlatformerAnimation2D.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Collections.Generic;
 
 namespace PC2D
 {
@@ -11,21 +12,55 @@ namespace PC2D
     public class PlatformerAnimation2D : MonoBehaviour
     {
         public float jumpRotationSpeed;
+        public bool jumpPlayOnce;
         public GameObject visualChild;
 
         private PlatformerMotor2D _motor;
         private Animator _animator;
         private bool _isJumping;
+        private bool _jumpPlayed = false;
         private bool _currentFacingLeft;
+
+        private int _animationIdle;
+        private int _animationWalk;
+        private int _animationJump;
+        private int _animationFall;
+        private int _animationDash;
+        private int _animationCling;
+        private int _animationSlip;
+        private int _animationOnCorner;
+
+        private Dictionary<int, bool> _hasAnimation = new Dictionary<int, bool>();
 
         // Use this for initialization
         void Start()
         {
             _motor = GetComponent<PlatformerMotor2D>();
             _animator = visualChild.GetComponent<Animator>();
-            _animator.Play("Idle");
+
+            _animationIdle = Animator.StringToHash("Idle");
+            _animationWalk = Animator.StringToHash("Walk");
+            _animationJump = Animator.StringToHash("Jump");
+            _animationFall = Animator.StringToHash("Fall");
+            _animationDash = Animator.StringToHash("Dash");
+            _animationCling = Animator.StringToHash("Cling");
+            _animationSlip = Animator.StringToHash("Slip");
+            _animationOnCorner = Animator.StringToHash("On Corner");
+
+            CheckAnimation(_animationIdle);
+            CheckAnimation(_animationWalk);
+            CheckAnimation(_animationJump);
+            CheckAnimation(_animationFall);
+            CheckAnimation(_animationDash);
+            CheckAnimation(_animationCling);
+            CheckAnimation(_animationSlip);
+            CheckAnimation(_animationOnCorner);
+
+            PlayAnimation(_animationIdle);
 
             _motor.onJump += SetCurrentFacingLeft;
+            _motor.onJump += ResetJumpPlayed;
+            _motor.onLanded += ResetJumpPlayed;
         }
 
         // Update is called once per frame
@@ -37,7 +72,10 @@ namespace PC2D
                                  _motor.motorState == PlatformerMotor2D.MotorState.FallingFast))
             {
                 _isJumping = true;
-                _animator.Play("Jump");
+                if (!_jumpPlayed)
+                {
+                    PlayAnimation(_animationJump);
+                }
 
                 if (_motor.velocity.x <= -0.1f)
                 {
@@ -59,34 +97,34 @@ namespace PC2D
                 if (_motor.motorState == PlatformerMotor2D.MotorState.Falling ||
                                  _motor.motorState == PlatformerMotor2D.MotorState.FallingFast)
                 {
-                    _animator.Play("Fall");
+                    PlayAnimation(_animationFall);
                 }
                 else if (_motor.motorState == PlatformerMotor2D.MotorState.WallSliding ||
                          _motor.motorState == PlatformerMotor2D.MotorState.WallSticking)
                 {
-                    _animator.Play("Cling");
+                    PlayAnimation(_animationCling);
                 }
                 else if (_motor.motorState == PlatformerMotor2D.MotorState.OnCorner)
                 {
-                    _animator.Play("On Corner");
+                    PlayAnimation(_animationOnCorner);
                 }
                 else if (_motor.motorState == PlatformerMotor2D.MotorState.Slipping)
                 {
-                    _animator.Play("Slip");
+                    PlayAnimation(_animationSlip);
                 }
                 else if (_motor.motorState == PlatformerMotor2D.MotorState.Dashing)
                 {
-                    _animator.Play("Dash");
+                    PlayAnimation(_animationDash);
                 }
                 else
                 {
                     if (_motor.velocity.sqrMagnitude >= 0.1f * 0.1f)
                     {
-                        _animator.Play("Walk");
+                        PlayAnimation(_animationWalk);
                     }
                     else
                     {
-                        _animator.Play("Idle");
+                        PlayAnimation(_animationIdle);
                     }
                 }
             }
@@ -100,11 +138,15 @@ namespace PC2D
             {
                 valueCheck = _motor.velocity.x;
             }
-            
-            if (Mathf.Abs(valueCheck) >= 0.1f)
+
+            if (valueCheck >= 0.1f)
             {
-                Vector3 newScale = visualChild.transform.localScale;
-                newScale.x = Mathf.Abs(newScale.x) * ((valueCheck > 0) ? 1.0f : -1.0f);
+                visualChild.transform.localScale = Vector3.one;
+            }
+            else if (valueCheck <= -0.1f)
+            {
+                Vector3 newScale = Vector3.one;
+                newScale.x = -1;
                 visualChild.transform.localScale = newScale;
             }
         }
@@ -112,6 +154,42 @@ namespace PC2D
         private void SetCurrentFacingLeft()
         {
             _currentFacingLeft = _motor.facingLeft;
+        }
+
+        private void ResetJumpPlayed()
+        {
+            _jumpPlayed = false;
+        }
+
+        private void PlayAnimation(int animation)
+        {
+            if (HasAnimation(animation))
+            {
+                _animator.Play(animation);
+
+                if (jumpPlayOnce && animation == _animationJump)
+                {
+                    _jumpPlayed = true;
+                }
+            }
+        }
+
+        private bool HasAnimation(int animation)
+        {
+            if (_hasAnimation.ContainsKey(animation))
+            {
+                return _hasAnimation[animation];
+            }
+
+            return false;
+        }
+
+        private void CheckAnimation(int animation)
+        {
+            if (!_hasAnimation.ContainsKey(animation))
+            {
+                _hasAnimation.Add(animation, _animator.HasState(0, animation));
+            }
         }
     }
 }


### PR DESCRIPTION
Stores animations as hashes instead of strings, checks if animations exist on load and only plays those that do so that animator script is agnostic of animation controller. Also adds ability to mark jump animation as play once so that jump doesn't loop. Ability to play jump animation is reset when controller lands or a mid-air jump is started.
