### PR TITLE
Adding colliding slopes angle to 'information'

### DIFF
--- a/Assets/PC2D/Editor/PlatformerMotor2DEditor.cs
+++ b/Assets/PC2D/Editor/PlatformerMotor2DEditor.cs
@@ -73,6 +73,7 @@ public class PlatformerMotor2DEditor : Editor
         "Minimum Speed to Move Up Slippery Slope");
 
     private readonly Property SLOPES_SPEED_MULTIPLIER = new Property("speedMultiplierOnSlope", "Speed Multiplier on Slopes");
+    private readonly Property SLOPE_NORMAL = new Property("slopeNormal", "Touching slope angle");
     private readonly Property STICK_TO_GROUND = new Property("stickOnGround", "Stick to Ground");
     private readonly Property STICK_CHECK_DISTANCE = new Property("distanceToCheckToStick", "Ground Check Distance to Stick");
 
@@ -525,7 +526,13 @@ public class PlatformerMotor2DEditor : Editor
                 _properties[WALL_SLIDE_SPEED.name].floatValue / _properties[TIME_TO_WALL_SLIDE_SPEED.name].floatValue);
         }
 
-
+        if (_properties[ENABLE_SLOPES.name].boolValue)
+        {
+            sb.AppendFormat(
+                "\nColliding slope angle: {0}",
+                (Vector2.Angle(_properties[SLOPE_NORMAL.name].vector2Value, Vector2.up)));
+        }
+        
         return sb.ToString();
     }
 

--- a/Assets/PC2D/Scripts/PlatformerMotor2D.cs
+++ b/Assets/PC2D/Scripts/PlatformerMotor2D.cs
@@ -641,7 +641,7 @@ public class PlatformerMotor2D : MonoBehaviour
     /// <summary>
     /// The normal of the slope the motor is on. This value doesn't have meaning unless onSlope is true.
     /// </summary>
-    public Vector2 slopeNormal { get; private set; }
+    public Vector2 slopeNormal;
 
     /// <summary>
     /// Call this to have the GameObject try to jump, once called it will be handled in the FixedUpdate tick. The y axis is
@@ -3216,6 +3216,7 @@ public class PlatformerMotor2D : MonoBehaviour
                 Vector2 origin = new Vector2(_collider2D.bounds.max.x, _collider2D.bounds.min.y);
                 Vector2 rightNormal = Vector2.zero;
                 Vector2 leftNormal = Vector2.zero;
+                slopeNormal = Vector2.up;
 
                 closestHit = GetClosestHit(origin, dir, _cornerDistanceCheck, false);
 


### PR DESCRIPTION
Added the information on the slope colliding with the motor collider angle for easier level design and tweak. I had to change the slopeNormal to be a property instead of getter with private setter otherwise it wouldn't show up at properties retrieved by the SerializedProperty inside OnEnable (if there's any workaround feel free to refactor).